### PR TITLE
sun4i-codec: enable audio on nanopi-neo-air

### DIFF
--- a/sound/soc/sunxi/Makefile
+++ b/sound/soc/sunxi/Makefile
@@ -1,6 +1,6 @@
+obj-$(CONFIG_SND_SUN8I_CODEC_ANALOG) += sun8i-codec-analog.o
 obj-$(CONFIG_SND_SUN4I_CODEC) += sun4i-codec.o
 obj-$(CONFIG_SND_SUN4I_I2S) += sun4i-i2s.o
 obj-$(CONFIG_SND_SUN4I_SPDIF) += sun4i-spdif.o
-obj-$(CONFIG_SND_SUN8I_CODEC_ANALOG) += sun8i-codec-analog.o
 obj-$(CONFIG_SND_SUN8I_CODEC) += sun8i-codec.o
 obj-$(CONFIG_SND_SUN8I_I2S) += sun8i-i2s.o


### PR DESCRIPTION
The driver sun4i-codec relies on sun8i-codec-analog but the
latter was not correctly loaded prior the probe() of sun4i-codec.
This modification provokes the early load of sun8i-codec-analog.