### PR TITLE
Update quirks.c for Native DSD Support with XMOS U208 USB Interface

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1368,6 +1368,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x20b1, 0x2009): /* DIYINHK DSD DXD 384kHz USB to I2S/DSD */
 	case USB_ID(0x20b1, 0x2023): /* JLsounds I2SoverUSB */
 	case USB_ID(0x20b1, 0x3023): /* Aune X1S 32BIT/384 DSD DAC */
+	case USB_ID(0x20b1, 0x3086): /* ARMATURE Hecate */
 	case USB_ID(0x2616, 0x0106): /* PS Audio NuWave DAC */
 		if (fp->altsetting == 3)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;


### PR DESCRIPTION
Add support for Native DSD format to Armature HECATE USB interface device. This card is similar to the Singxer F1 device, both use the same XMOS U208 chipset with the same 'chip->usb_id' tag.
This modification has been tested successfully with the Armature Hecate board.